### PR TITLE
Add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[metadata]
+name = "orwrap"
+author = "Marian Meyer"
+version = "19.8.2"
+
+[project]
+dependencies = [
+  "ortools",
+  "numpy",
+  "scipy",
+  "cython",
+]
+
+[build-system]
+requires = [
+  "wheel",
+  "cython",
+  "ortools",
+  "setuptools",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a pyproject.toml file, which is advised to be preferred to a setup.py in PEP 518. This makes it possible, for instance, to install Orwrap with Poetry.